### PR TITLE
feat - retain input JSON value on browser refresh or close

### DIFF
--- a/js/jsonSchemaBuilder.js
+++ b/js/jsonSchemaBuilder.js
@@ -39,6 +39,7 @@ readAttributeToTitleDesc("properties/attributeToTitleDesc.json");
 readAttributeProperties("properties/attributeProperties.json");
 
 $(document).ready(function () {
+	jsonSchemaEditor.getDoc().setValue(localStorage.getItem('vivek9237-json-validator'));
 	$('input#wordwrapCheckbox').change(
 		function () {
 			if ($(this).is(':checked')) {
@@ -89,6 +90,7 @@ var jsonSchemaEditor = CodeMirror.fromTextArea
 	});
 jsonSchemaEditor.on('change', jsonSchemaEditor => {
 	try {
+		localStorage.setItem('vivek9237-json-validator', jsonSchemaEditor.getDoc().getValue());
 		clearTimeout(waiting);
 		waiting = setTimeout(updateHints, 500);
 	} catch (err) {


### PR DESCRIPTION
Implemented a feature to retain the input JSON value even if the browser is refreshed or closed. This enhancement improves user experience by preventing data loss due to accidental browser actions. The input JSON value is now stored using localStorage and automatically reloaded when the user revisits the application, ensuring data persistence and reliability.